### PR TITLE
hotfix(backend): discipline order in contest.getOngoing 

### DIFF
--- a/src/app/(app)/_layout/components/navbar.tsx
+++ b/src/app/(app)/_layout/components/navbar.tsx
@@ -17,7 +17,6 @@ import {
   CodeIcon,
 } from '@/frontend/ui'
 import { DEFAULT_DISCIPLINE } from '@/types'
-import { ESLINT_DEFAULT_DIRS } from 'next/dist/lib/constants'
 
 type NavbarProps = {
   variant: 'vertical' | 'horizontal'

--- a/src/backend/api/routers/contest.ts
+++ b/src/backend/api/routers/contest.ts
@@ -88,7 +88,12 @@ export const contestRouter = createTRPCRouter({
           eq(roundSessionTable.roundId, roundTable.id),
         ),
       )
+      .innerJoin(
+        disciplineTable,
+        eq(disciplineTable.slug, roundTable.disciplineSlug),
+      )
       .where(eq(contestTable.isOngoing, true))
+      .orderBy(disciplineTable.createdAt)
 
     const ongoing = rows[0]
     if (!ongoing) return null


### PR DESCRIPTION
- **fix(app): use proper new URL().searchParams.append to escape special symbols in tnoodle requests**
- **test deploy speed**
- **`todo.md`**
- **hotfix: remove redirect for ongoing**
- **hotfix(backend): discipline order in contest.getOngoing**
