### PR TITLE
scrollToOwn on session finished; personal best confetti

### DIFF
--- a/drizzle/0005_useful_pyro.sql
+++ b/drizzle/0005_useful_pyro.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "round_session" ADD CONSTRAINT "round_id_contestant_id" UNIQUE("round_id","contestant_id");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,881 @@
+{
+  "id": "8180b9a6-3bfb-461d-bb0e-47e45a7ce9e1",
+  "prevId": "a1ce46fc-5ac8-4165-bc19-a78caff7dc53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_account_id": {
+          "name": "provider_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_provider_provider_account_id_pk": {
+          "name": "account_provider_provider_account_id_pk",
+          "columns": [
+            "provider",
+            "provider_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.auth_session": {
+      "name": "auth_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "t_user_id_idx": {
+          "name": "t_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "auth_session_user_id_user_id_fk": {
+          "name": "auth_session_user_id_user_id_fk",
+          "tableFrom": "auth_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finished_registration": {
+          "name": "finished_registration",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest": {
+      "name": "contest",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expected_end_date": {
+          "name": "expected_end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_ongoing": {
+          "name": "is_ongoing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_initial": {
+          "name": "system_initial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "contest_slug_unique": {
+          "name": "contest_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discipline": {
+      "name": "discipline",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round_session": {
+      "name": "round_session",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "round_session_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "contestant_id": {
+          "name": "contestant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_ms": {
+          "name": "avg_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dnf": {
+          "name": "is_dnf",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_finished": {
+          "name": "is_finished",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "avg_ms_idx": {
+          "name": "avg_ms_idx",
+          "columns": [
+            {
+              "expression": "avg_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "round_session_contestant_id_user_id_fk": {
+          "name": "round_session_contestant_id_user_id_fk",
+          "tableFrom": "round_session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "contestant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "round_session_round_id_round_id_fk": {
+          "name": "round_session_round_id_round_id_fk",
+          "tableFrom": "round_session",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "round_id_contestant_id": {
+          "name": "round_id_contestant_id",
+          "nullsNotDistinct": false,
+          "columns": [
+            "round_id",
+            "contestant_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "round_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "contest_slug": {
+          "name": "contest_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discipline_slug": {
+          "name": "discipline_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_contest_slug_contest_slug_fk": {
+          "name": "round_contest_slug_contest_slug_fk",
+          "tableFrom": "round",
+          "tableTo": "contest",
+          "columnsFrom": [
+            "contest_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "round_discipline_slug_discipline_slug_fk": {
+          "name": "round_discipline_slug_discipline_slug_fk",
+          "tableFrom": "round",
+          "tableTo": "discipline",
+          "columnsFrom": [
+            "discipline_slug"
+          ],
+          "columnsTo": [
+            "slug"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scramble": {
+      "name": "scramble",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "scramble_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_extra": {
+          "name": "is_extra",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "CASE WHEN position IN ('E1', 'E2') THEN TRUE ELSE FALSE END",
+            "type": "stored"
+          }
+        },
+        "moves": {
+          "name": "moves",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scramble_round_id_round_id_fk": {
+          "name": "scramble_round_id_round_id_fk",
+          "tableFrom": "scramble",
+          "tableTo": "round",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "round_position_unique": {
+          "name": "round_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "round_id",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solve": {
+      "name": "solve",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "solve_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "scramble_id": {
+          "name": "scramble_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round_session_id": {
+          "name": "round_session_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "time_ms": {
+          "name": "time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_dnf": {
+          "name": "is_dnf",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solution": {
+          "name": "solution",
+          "type": "varchar(10000)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "time_ms_idx": {
+          "name": "time_ms_idx",
+          "columns": [
+            {
+              "expression": "time_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "solve_scramble_id_scramble_id_fk": {
+          "name": "solve_scramble_id_scramble_id_fk",
+          "tableFrom": "solve",
+          "tableTo": "scramble",
+          "columnsFrom": [
+            "scramble_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "solve_round_session_id_round_session_id_fk": {
+          "name": "solve_round_session_id_round_session_id_fk",
+          "tableFrom": "solve",
+          "tableTo": "round_session",
+          "columnsFrom": [
+            "round_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "round_session_scramble_unique": {
+          "name": "round_session_scramble_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "round_session_id",
+            "scramble_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_simulator_settings": {
+      "name": "user_simulator_settings",
+      "schema": "",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "byDefault",
+            "name": "user_simulator_settings_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "2147483647",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "animation_duration": {
+          "name": "animation_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "inspection_voice_alert": {
+          "name": "inspection_voice_alert",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Male'"
+        },
+        "camera_position_theta": {
+          "name": "camera_position_theta",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "camera_position_phi": {
+          "name": "camera_position_phi",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_simulator_settings_user_id_user_id_fk": {
+          "name": "user_simulator_settings_user_id_user_id_fk",
+          "tableFrom": "user_simulator_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1744620741264,
       "tag": "0004_green_nomad",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1744956548790,
+      "tag": "0005_useful_pyro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/(app)/(dashboard)/_components/best-solves.tsx
+++ b/src/app/(app)/(dashboard)/_components/best-solves.tsx
@@ -56,7 +56,7 @@ export function BestSolves({
           <span className='hidden flex-1 sm:block'>Type/Nickname</span>
           <span className='mr-4 w-24 text-center sm:mr-0'>Single time</span>
           <div aria-hidden className='invisible h-0'>
-            <OpenLeaderboardButton discipline='3x3' />
+            <OpenLeaderboardButton discipline='3by3' />
           </div>
         </div>
 
@@ -126,7 +126,7 @@ function SolveRow({ solve, isFirstOnPage }: SolveProps) {
   )
 }
 
-function OpenLeaderboardButton({ discipline }: { discipline: string }) {
+function OpenLeaderboardButton({ discipline }: { discipline: Discipline }) {
   const ariaLabel = `leaderboard`
   const ariaDescription = `Open leaderboard for ${discipline}`
   return (

--- a/src/app/(app)/contests/[contestSlug]/results/_components/session-list.tsx
+++ b/src/app/(app)/contests/[contestSlug]/results/_components/session-list.tsx
@@ -16,11 +16,13 @@ export function SessionList({
   discipline,
   initialData,
   scrollToId,
+  scrollToOwn,
 }: {
   contestSlug: string
   discipline: Discipline
   initialData?: RouterOutputs['contest']['getContestResults']
   scrollToId?: number
+  scrollToOwn?: boolean
 }) {
   const trpc = useTRPC()
   const { data: sessions } = useSuspenseQuery(
@@ -44,6 +46,11 @@ export function SessionList({
     },
     [containerRef, performScrollToIdx],
   )
+
+  useEffect(() => {
+    if (scrollToOwn)
+      scrollAndGlow(sessions.findIndex((result) => result.session.isOwn))
+  }, [scrollToOwn, sessions, scrollAndGlow])
 
   useEffect(() => {
     if (scrollToId)

--- a/src/app/(app)/contests/[contestSlug]/results/page.tsx
+++ b/src/app/(app)/contests/[contestSlug]/results/page.tsx
@@ -22,7 +22,7 @@ export default async function ContestResultsPage({
   searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   const { contestSlug } = await params
-  const { discipline, scrollToId } = await searchParams
+  const { discipline, scrollToId, scrollToOwn } = await searchParams
   if (!isDiscipline(discipline))
     redirect(
       `/contests/${contestSlug}/results?discipline=${DEFAULT_DISCIPLINE}`,
@@ -70,6 +70,7 @@ export default async function ContestResultsPage({
           contestSlug={contestSlug}
           discipline={discipline}
           scrollToId={Number(scrollToId)}
+          scrollToOwn={Boolean(scrollToOwn)}
         />
       </Suspense>
     </>
@@ -80,10 +81,12 @@ async function PageContent({
   contestSlug,
   discipline,
   scrollToId,
+  scrollToOwn,
 }: {
   contestSlug: string
   discipline: Discipline
   scrollToId?: number
+  scrollToOwn?: boolean
 }) {
   const { data: initialData, error } = await tryCatchTRPC(
     api.contest.getContestResults({
@@ -106,6 +109,7 @@ async function PageContent({
       contestSlug={contestSlug}
       discipline={discipline}
       scrollToId={scrollToId}
+      scrollToOwn={scrollToOwn}
     />
   )
 }

--- a/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/simulator.lazy.tsx
+++ b/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/simulator.lazy.tsx
@@ -10,13 +10,13 @@ import {
   INSPECTION_DNF_THRESHHOLD_MS,
   INSPECTION_PLUS_TWO_THRESHHOLD_MS,
 } from './constants'
-import type { ResultDnfish } from '@/types'
+import type { Discipline, ResultDnfish } from '@/types'
 import type { userSimulatorSettingsTable } from '@/backend/db/schema'
 import type { SimulatorCameraPosition } from 'vendor/cstimer'
 import { useIsTouchDevice } from '@/frontend/utils/use-media-query'
 import { cn } from '@/frontend/utils/cn'
 
-export type InitSolveData = { scramble: string; discipline: string }
+export type InitSolveData = { scramble: string; discipline: Discipline }
 
 export type SimulatorSolve = {
   result: ResultDnfish

--- a/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/use-simulator.ts
+++ b/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/use-simulator.ts
@@ -1,4 +1,4 @@
-import { isDiscipline, type SimulatorSettings } from '@/types'
+import { type Discipline, type SimulatorSettings } from '@/types'
 import {
   type SimulatorCameraPosition,
   type TwistySimulatorMoveListener,
@@ -30,14 +30,11 @@ export function useTwistySimulator({
   containerRef: RefObject<HTMLElement | null>
   onMove: SimulatorMoveListener
   scramble: string | undefined
-  discipline: string
+  discipline: Discipline
   settings: SimulatorSettings
   touchCubeEnabled: boolean
   setCameraPosition: (pos: SimulatorCameraPosition) => void
 }) {
-  if (!isDiscipline(discipline))
-    throw new Error(`[SIMULATOR] unsupported discipline: ${discipline}`)
-
   const [puzzle, setPuzzle] = useState<TwistySimulatorPuzzle | undefined>()
 
   useEffect(() => {

--- a/src/app/(app)/contests/[contestSlug]/solve/_components/solve-contest-form.tsx
+++ b/src/app/(app)/contests/[contestSlug]/solve/_components/solve-contest-form.tsx
@@ -41,7 +41,7 @@ export function SolveContestForm({
     },
     {
       retry: (_, err) =>
-        err.data?.code !== 'FORBIDDEN' && err.data?.code !== 'UNAUTHORIZED', // TODO: why does removing unauthorized result in server errors
+        err.data?.code !== 'FORBIDDEN' && err.data?.code !== 'UNAUTHORIZED', // TODO: why does removing unauthorized result in server errors?
       initialData,
     },
   )
@@ -50,11 +50,13 @@ export function SolveContestForm({
     isFetching: isStateFetching,
     error,
   } = useSuspenseQuery(stateQuery)
-  if (error?.data?.code === 'FORBIDDEN')
+  if (error?.data?.code === 'FORBIDDEN') {
+    console.log(state)
     redirect(
-      `/contests/${contestSlug}/results?discipline=${discipline}`,
+      `/contests/${contestSlug}/results?discipline=${discipline}&scrollToOwn=true`,
       RedirectType.replace,
     )
+  }
 
   if (error)
     throw new TRPCError({ message: error.message, code: error.data!.code })

--- a/src/app/(app)/contests/[contestSlug]/solve/page.tsx
+++ b/src/app/(app)/contests/[contestSlug]/solve/page.tsx
@@ -159,15 +159,15 @@ async function PageContent({
 }
 
 const SPLASH_TEXTS = [
-  'You have five attempts to solve the contest.',
+  'You have five attempts to solve the contest',
   'GLHF!',
   'No DNFs today, huh?',
   "It's not a +2 if no one is watching, right?",
   'The cube just popped!',
   'Shaky hands?',
   'These are TNoodle scrambles btw',
-  '8 seconds! 12 seconds! Go! Just kidding.',
-  "Feliks Zemdegs would've been proud of you.",
+  '8 seconds! 12 seconds! Go! Just kidding',
+  "Feliks Zemdegs would've been proud of you",
   <>
     Check out{' '}
     <Link

--- a/src/app/(app)/contests/[contestSlug]/watch/[solveId]/_components/tps-hint-popover.tsx
+++ b/src/app/(app)/contests/[contestSlug]/watch/[solveId]/_components/tps-hint-popover.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Popover, PopoverTrigger, PopoverContent } from '@/frontend/ui'
+import { PopoverPortal } from '@radix-ui/react-popover'
+import { useState, type ReactNode } from 'react'
+
+export function TpsHintPopover({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+
+  const handleMouseEnter = () => {
+    setOpen(true)
+  }
+
+  const handleMouseLeave = () => {
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        className='outline-none'
+      >
+        {children}
+      </PopoverTrigger>
+      <PopoverPortal>
+        <PopoverContent
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+        >
+          Turns per second
+        </PopoverContent>
+      </PopoverPortal>
+    </Popover>
+  )
+}

--- a/src/app/(app)/contests/[contestSlug]/watch/[solveId]/_components/twisty-section.tsx
+++ b/src/app/(app)/contests/[contestSlug]/watch/[solveId]/_components/twisty-section.tsx
@@ -25,21 +25,29 @@ export function TwistySection({
   scramble: string
   discipline: Discipline
 }) {
-  const player = useTwistyPlayer({
+  const { player, startIndex } = useTwistyPlayer({
     solution,
     scramble,
     discipline,
   })
   if (!player) return null
 
-  return <TwistySectionContent player={player} scramble={scramble} />
+  return (
+    <TwistySectionContent
+      startIndex={startIndex}
+      player={player}
+      scramble={scramble}
+    />
+  )
 }
 
 function TwistySectionContent({
   player,
+  startIndex,
   scramble,
 }: {
   player: Player
+  startIndex: number
   scramble: string
 }) {
   const movesWrapperRef = useRef<HTMLDivElement | null>(null)
@@ -94,7 +102,10 @@ function TwistySectionContent({
           <AccordionItem title='Solve' className='flex-1'>
             <div className='flex h-full flex-col border-t border-grey-60 pt-2'>
               <div className='scrollbar -ml-1 -mt-1 flex-grow basis-0 overflow-y-auto pl-1 pr-2 pt-1 md:overflow-y-visible'>
-                <TwistyAlgViewer twistyPlayer={player} />
+                <TwistyAlgViewer
+                  twistyPlayer={player}
+                  startIndex={startIndex}
+                />
               </div>
             </div>
           </AccordionItem>

--- a/src/app/(app)/contests/[contestSlug]/watch/[solveId]/page.tsx
+++ b/src/app/(app)/contests/[contestSlug]/watch/[solveId]/page.tsx
@@ -15,10 +15,10 @@ import { ShareSolveButton } from './_components/share-button'
 import { SpinningBorder } from '@/frontend/ui/spinning-border'
 import tailwindConfig from 'tailwind.config'
 import { cn } from '@/frontend/utils/cn'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/frontend/ui/tooltip'
 import { Alg } from '@vscubing/cubing/alg'
 import { isRotation } from '@/utils/is-rotation'
 import { removeSolutionComments } from '@/utils/remove-solution-comments'
+import { TpsHintPopover } from './_components/tps-hint-popover'
 
 type PathParams = { contestSlug: string; solveId: string }
 export default async function WatchSolvePage({
@@ -167,11 +167,8 @@ function SolveTPS({
 
   return (
     <span>
-      {turnCount} turns, {tps} {''}
-      <Tooltip>
-        <TooltipTrigger>TPS</TooltipTrigger>
-        <TooltipContent>Turns per second</TooltipContent>
-      </Tooltip>
+      {turnCount} turns, {tps} TPS {''}
+      <TpsHintPopover>(?)</TpsHintPopover>
     </span>
   )
 }

--- a/src/app/(app)/contests/[contestSlug]/watch/[solveId]/page.tsx
+++ b/src/app/(app)/contests/[contestSlug]/watch/[solveId]/page.tsx
@@ -9,7 +9,6 @@ import { Suspense, type ReactNode } from 'react'
 import { LayoutSectionHeader } from '@/app/(app)/_layout'
 import { LayoutHeaderTitlePortal } from '@/app/(app)/_layout/layout-header'
 import { NavigateBackButton } from '@/frontend/shared/navigate-back-button'
-import { formatSolveTime } from '@/utils/format-solve-time'
 import Link from 'next/link'
 import { ShareSolveButton } from './_components/share-button'
 import { SpinningBorder } from '@/frontend/ui/spinning-border'
@@ -19,6 +18,7 @@ import { Alg } from '@vscubing/cubing/alg'
 import { isRotation } from '@/utils/is-rotation'
 import { removeSolutionComments } from '@/utils/remove-solution-comments'
 import { TpsHintPopover } from './_components/tps-hint-popover'
+import { SolveTimeLabel } from '@/frontend/shared/solve-time-button'
 
 type PathParams = { contestSlug: string; solveId: string }
 export default async function WatchSolvePage({
@@ -69,6 +69,7 @@ async function PageContentWithShell({ solveId, contestSlug }: PathParams) {
       timeMs={solve.timeMs}
       scramblePosition={expandScramblePosition(solve.position)}
       isOwn={solve.isOwn}
+      isPersonalBest={solve.isPersonalBest}
       solution={solve.solution}
     >
       <TwistySection
@@ -90,6 +91,7 @@ function PageShell({
   isOwn,
   solution,
   children,
+  isPersonalBest,
 }: {
   discipline: Discipline
   contestSlug: string
@@ -100,6 +102,7 @@ function PageShell({
   username: string
   children: ReactNode
   isOwn?: boolean
+  isPersonalBest?: boolean
 }) {
   return (
     <section className='flex flex-1 flex-col gap-3'>
@@ -134,9 +137,13 @@ function PageShell({
             <div className='sm:min-h-14'>
               <p className='title-h3 mb-1'>{username}</p>
               <p className='text-large text-grey-20'>
-                <span className='mr-1'>{formatSolveTime(timeMs ?? 0)} </span>
+                <SolveTimeLabel
+                  timeMs={timeMs ?? 0}
+                  className='mr-4 min-w-0'
+                  isFestive={isPersonalBest}
+                ></SolveTimeLabel>
                 <span className='text-grey-40'>
-                  <SolveTPS solution={solution} timeMs={timeMs} />
+                  <SolveTps solution={solution} timeMs={timeMs} />
                 </span>
               </p>
             </div>
@@ -150,7 +157,7 @@ function PageShell({
   )
 }
 
-function SolveTPS({
+function SolveTps({
   solution,
   timeMs,
 }: {

--- a/src/app/landing/_sections/hero-section/twisty-section.tsx
+++ b/src/app/landing/_sections/hero-section/twisty-section.tsx
@@ -9,7 +9,7 @@ import {
 import { useEffect } from 'react'
 
 export default function TwistySection() {
-  const player = useTwistyPlayer(VALK_474_WR)
+  const { player } = useTwistyPlayer(VALK_474_WR)
 
   useEffect(() => player?.play(), [player])
 

--- a/src/backend/db/schema/contest.ts
+++ b/src/backend/db/schema/contest.ts
@@ -86,7 +86,10 @@ export const roundSessionTable = pgTable(
     isDnf: d.boolean('is_dnf'),
     isFinished: d.boolean('is_finished').default(false).notNull(),
   }),
-  (t) => [index('avg_ms_idx').on(t.avgMs)],
+  (t) => [
+    index('avg_ms_idx').on(t.avgMs),
+    unique('round_id_contestant_id').on(t.roundId, t.contestantId),
+  ],
 )
 
 export const solveTable = pgTable(

--- a/src/frontend/shared/sign-in-button.tsx
+++ b/src/frontend/shared/sign-in-button.tsx
@@ -2,7 +2,6 @@
 
 import { cn } from '@/frontend/utils/cn'
 import { GhostButton, GoogleIcon, PrimaryButton, toast } from '@/frontend/ui'
-import Link from 'next/link'
 import { useEffect, type MouseEventHandler } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { GOOGLE_AUTH_ERROR_SEARCH_PARAM } from '../../app/api/auth/google/error-search-param'

--- a/src/frontend/shared/solve-time-button.tsx
+++ b/src/frontend/shared/solve-time-button.tsx
@@ -69,7 +69,7 @@ export function SolveTimeLinkOrDnf({
 }
 
 const solveTimeLabelVariants = cva(
-  'vertical-alignment-fix inline-flex h-8 min-w-24 items-center justify-center',
+  'vertical-alignment-fix relative inline-flex h-8 min-w-24 items-center justify-center',
   {
     variants: {
       variant: { average: 'text-yellow-100', dnf: 'text-red-80' },
@@ -80,6 +80,7 @@ type SolveTimeLabelProps = {
   timeMs?: number // this is loosely typed without ResultDnfish because isPlaceholder and isAverage are tricky
   isDnf?: boolean
   isPlaceholder?: boolean
+  isFestive?: boolean
   isAverage?: boolean
 } & Omit<ComponentProps<'span'>, 'children'>
 export function SolveTimeLabel({
@@ -87,6 +88,7 @@ export function SolveTimeLabel({
   timeMs,
   isDnf = false,
   isPlaceholder = false,
+  isFestive = false,
   isAverage,
   className,
   ...props
@@ -116,6 +118,13 @@ export function SolveTimeLabel({
       className={cn(solveTimeLabelVariants({ variant, className }))}
       ref={ref}
     >
+      {isFestive && (
+        <Image
+          src={confettiImg}
+          alt=''
+          className='pointer-events-none absolute left-1/2 top-1/2 max-w-none -translate-x-1/2 -translate-y-1/2'
+        />
+      )}
       {content}
     </span>
   )

--- a/src/frontend/shared/twisty/twisty-alg-viewer.tsx
+++ b/src/frontend/shared/twisty/twisty-alg-viewer.tsx
@@ -6,10 +6,12 @@ import { useRef, useEffect } from 'react'
 
 interface TwistyAlgViewerProps {
   twistyPlayer: Player
+  startIndex?: number
   className?: string
 }
 export const TwistyAlgViewer = ({
   className,
+  startIndex = 0,
   twistyPlayer,
 }: TwistyAlgViewerProps) => {
   const spanRef = useRef<HTMLSpanElement | null>(null)
@@ -17,9 +19,10 @@ export const TwistyAlgViewer = ({
   useEffect(() => {
     const algViewer = new AlgViewer({ twistyPlayer })
     spanRef.current?.appendChild(algViewer)
+    void algViewer.jumpToIndex(startIndex, false)
 
     return () => algViewer.remove()
-  }, [className, twistyPlayer])
+  }, [twistyPlayer, startIndex])
 
   return <span className={className} ref={spanRef} />
 }

--- a/src/frontend/shared/twisty/use-twisty-player.ts
+++ b/src/frontend/shared/twisty/use-twisty-player.ts
@@ -13,14 +13,15 @@ export function useTwistyPlayer({
   discipline: Discipline
 }) {
   const [player, setPlayer] = useState<TwistyPlayer | null>(null)
+  const [startIndex, setStartIndex] = useState(0)
 
   useEffect(() => {
     void (async () => {
-      const { solution, animLeaves } = await doEverything(
-        scramble,
-        rawSolution,
-        discipline,
-      )
+      const {
+        solution,
+        animLeaves,
+        startIndex: _startIndex,
+      } = await doEverything(scramble, rawSolution, discipline)
 
       const newPlayer = new TwistyPlayer({
         controlPanel: 'none',
@@ -40,11 +41,15 @@ export function useTwistyPlayer({
       }
 
       setPlayer(newPlayer)
-      return () => setPlayer(null)
+      setStartIndex(_startIndex)
+      return () => {
+        setPlayer(null)
+        setStartIndex(0)
+      }
     })()
   }, [scramble, rawSolution, discipline])
 
-  return player
+  return { player, startIndex }
 }
 
 const TWISTY_PUZZLE_MAP: Record<Discipline, PuzzleID> = {

--- a/src/frontend/ui/discipline.tsx
+++ b/src/frontend/ui/discipline.tsx
@@ -1,9 +1,10 @@
 import { cn } from '@/frontend/utils/cn'
 import { type HTMLAttributes } from 'react'
 import { DisciplineIcon } from './icons'
+import type { Discipline } from '@/types'
 
-type DisciplineBadgeProps = HTMLAttributes<HTMLDivElement> & {
-  discipline: string
+type DisciplineBadgeProps = HTMLAttributes<HTMLSpanElement> & {
+  discipline: Discipline
 }
 export function DisciplineBadge({
   ref,

--- a/src/frontend/ui/icons.tsx
+++ b/src/frontend/ui/icons.tsx
@@ -37,7 +37,7 @@ import AverageIcon from '@/../public/icons/average.icon.svg'
 import SingleIcon from '@/../public/icons/single.icon.svg'
 import VscubingIcon from '@/../public/icons/vscubing.icon.svg'
 
-import { isDiscipline } from '@/types'
+import { type Discipline } from '@/types'
 import { cn } from '@/frontend/utils/cn'
 import { type HTMLAttributes } from 'react'
 
@@ -81,7 +81,7 @@ export {
 }
 
 type DisciplineIconProps = HTMLAttributes<SVGSVGElement> & {
-  discipline: string
+  discipline: Discipline
 }
 
 const ICONS = {
@@ -96,12 +96,8 @@ export function DisciplineIcon({
 }: DisciplineIconProps & {
   ref?: React.RefObject<SVGSVGElement>
 }) {
-  const Comp = isDiscipline(discipline) ? ICONS[discipline] : PlaceholderIcon
+  const Icon = ICONS[discipline]
   return (
-    <Comp {...props} ref={ref} className={cn('h-[27px] w-[27px]', className)} />
+    <Icon {...props} ref={ref} className={cn('h-[27px] w-[27px]', className)} />
   )
-}
-
-function PlaceholderIcon({ className }: { className?: string }) {
-  return <svg className={cn('animate-pulse bg-grey-60', className)}></svg>
 }

--- a/todo.md
+++ b/todo.md
@@ -12,7 +12,7 @@ BEFORE RELEASE:
 - [x] scroll to own result on round finish
 - [x] fix discipline: string everywhere
 - [x] skip preinspection
-- [ ] pb confetti in reconstruction
+- [x] pb confetti in reconstruction
 - [ ] wca auth
 - [ ] figure out the annoying auth bug
 - [ ] new posthog project

--- a/todo.md
+++ b/todo.md
@@ -10,7 +10,7 @@ BEFORE RELEASE:
 - [x] add db ping in the health check
 - [x] fix setSimulatorSettings firing unnecessarily
 - [x] scroll to own result on round finish
-- [ ] fix discipline: string everywhere
+- [x] fix discipline: string everywhere
 - [ ] skip preinspection
 - [ ] wca auth
 - [ ] figure out the annoying auth bug

--- a/todo.md
+++ b/todo.md
@@ -9,6 +9,7 @@ BEFORE RELEASE:
 - [x] license
 - [x] add db ping in the health check
 - [x] fix setSimulatorSettings firing unnecessarily
+- [x] scroll to own result on round finish
 - [ ] fix discipline: string everywhere
 - [ ] skip preinspection
 - [ ] wca auth

--- a/todo.md
+++ b/todo.md
@@ -11,7 +11,8 @@ BEFORE RELEASE:
 - [x] fix setSimulatorSettings firing unnecessarily
 - [x] scroll to own result on round finish
 - [x] fix discipline: string everywhere
-- [ ] skip preinspection
+- [x] skip preinspection
+- [ ] pb confetti in reconstruction
 - [ ] wca auth
 - [ ] figure out the annoying auth bug
 - [ ] new posthog project


### PR DESCRIPTION
- **fix(db): unique constraint `"round_id_contestant_id"`**
- **feat(frontend+backend): scrollToOwn on session finished**
- **fix(ui): remove periods from splash texts**
- **chore: ensure strong typing for discipline everywhere**
- **fix(watch): rework tps-hint-popover**
- **feat(watch): skip inspection by default**
- **feat(watch): personal best confetti**
