### PR TITLE
SolveOngoingLink in ongoing banner on mobile; Hint about leaderboard updates

### DIFF
--- a/src/app/(app)/(dashboard)/_components/ongoing-contest-banner.tsx
+++ b/src/app/(app)/(dashboard)/_components/ongoing-contest-banner.tsx
@@ -34,11 +34,6 @@ function BannerContent({
   ongoing: NonNullable<RouterOutputs['contest']['getOngoing']>
   className?: string
 }) {
-  const defaultDisciplineCapabilities = ongoing.disciplines.find(
-    (d) => d.slug === DEFAULT_DISCIPLINE,
-  )?.capabilities
-  const defaultDisciplineLink = `/contests/${ongoing.slug}/${defaultDisciplineCapabilities}?discipline=${DEFAULT_DISCIPLINE}`
-
   return (
     <div className={cn('flex h-44', className)}>
       <div className='relative mr-32'>
@@ -62,9 +57,7 @@ function BannerContent({
               <p className='title-h3 mb-2'>Duration</p>
               <Duration ongoing={ongoing} />
             </div>
-            <PrimaryButton asChild>
-              <Link href={defaultDisciplineLink}>Solve now</Link>
-            </PrimaryButton>
+            <SolveOngoingLink ongoing={ongoing} />
           </div>
         </div>
         <Divider className='absolute -right-40 top-0 h-full w-36' />
@@ -85,8 +78,9 @@ function BannerContentMobile({
     <div
       className={cn('flex h-44 sm:h-32 sm:flex-col sm:px-3 sm:py-4', className)}
     >
-      <div className='relative z-10 py-4 pl-4 sm:flex sm:items-center sm:gap-4 sm:p-0'>
+      <div className='relative z-10 flex flex-col items-start gap-4 py-4 pl-4 sm:gap-4 sm:p-0'>
         <Title />
+        <SolveOngoingLink ongoing={ongoing} className='sm:hidden' />
       </div>
 
       <div className='relative flex-1 sm:hidden'>
@@ -115,6 +109,25 @@ function BannerOnMaintenance() {
       </div>
       <ForegroundCubes className='sm:hidden' />
     </div>
+  )
+}
+
+function SolveOngoingLink({
+  ongoing,
+  className,
+}: {
+  ongoing: NonNullable<RouterOutputs['contest']['getOngoing']>
+  className?: string
+}) {
+  const defaultDisciplineCapabilities = ongoing.disciplines.find(
+    (d) => d.slug === DEFAULT_DISCIPLINE,
+  )?.capabilities
+  const defaultDisciplineLink = `/contests/${ongoing.slug}/${defaultDisciplineCapabilities}?discipline=${DEFAULT_DISCIPLINE}`
+
+  return (
+    <PrimaryButton asChild className={className}>
+      <Link href={defaultDisciplineLink}>Solve now</Link>
+    </PrimaryButton>
   )
 }
 

--- a/src/app/(app)/contests/[contestSlug]/solve/page.tsx
+++ b/src/app/(app)/contests/[contestSlug]/solve/page.tsx
@@ -168,6 +168,7 @@ const SPLASH_TEXTS = [
   'These are TNoodle scrambles btw',
   '8 seconds! 12 seconds! Go! Just kidding',
   "Feliks Zemdegs would've been proud of you",
+  'Crazy finger tricks!',
   <>
     Check out{' '}
     <Link

--- a/src/app/(app)/leaderboard/page.tsx
+++ b/src/app/(app)/leaderboard/page.tsx
@@ -33,6 +33,13 @@ import {
   AverageListShell,
   AverageResultSkeleton,
 } from './_components/average-list'
+import { ExclamationCircleIcon, HoverPopover } from '@/frontend/ui'
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipPortal,
+} from '@/frontend/ui/tooltip'
 
 export default async function LeaderboardPage({
   searchParams,
@@ -51,12 +58,31 @@ export default async function LeaderboardPage({
         <PageTitle type={type} />
       </Suspense>
       <NavigateBackButton />
-      <LayoutSectionHeader className='sticky top-0 z-10 flex justify-between'>
+      <LayoutSectionHeader className='sticky top-0 z-10 flex gap-10 md:gap-4'>
         <DisciplineSwitcher
           disciplines={DISCIPLINES}
           initialDiscipline={discipline}
         />
-        <LeaderboardTypeSwitcher initialType={type} />
+
+        <div className='flex flex-1 items-center gap-4 md:hidden'>
+          <ExclamationCircleIcon className='shrink-0' />
+          <p className='vertical-alignment-fix'>
+            The leaderboards are updated every time an ongoing contest ends.
+          </p>
+        </div>
+
+        <HoverPopover
+          content='The leaderboards are updated every time an ongoing contest ends.'
+          contentProps={{
+            className: 'border-b border-secondary-20 whitespace-normal',
+          }}
+        >
+          <span className='hidden md:block'>
+            <ExclamationCircleIcon />
+          </span>
+        </HoverPopover>
+
+        <LeaderboardTypeSwitcher initialType={type} className='ml-auto' />
       </LayoutSectionHeader>
 
       {type === 'single' && (

--- a/src/frontend/shared/leaderboard-type-switcher.tsx
+++ b/src/frontend/shared/leaderboard-type-switcher.tsx
@@ -9,8 +9,10 @@ import { AverageIcon, SingleIcon } from '../ui'
 
 export function LeaderboardTypeSwitcher({
   initialType,
+  className,
 }: {
   initialType?: LeaderboardType
+  className?: string
 }) {
   const [currentType, setCurrentType] = useState<LeaderboardType | undefined>(
     initialType,
@@ -30,7 +32,7 @@ export function LeaderboardTypeSwitcher({
   )
 
   return (
-    <div className='relative flex rounded-xl bg-grey-100'>
+    <div className={cn('relative flex rounded-xl bg-grey-100', className)}>
       <div
         className={cn(
           'transition-base absolute left-0 top-0 h-full w-[8.5rem] rounded-xl bg-secondary-20 sm:w-11',

--- a/src/frontend/shared/use-user.ts
+++ b/src/frontend/shared/use-user.ts
@@ -1,5 +1,5 @@
 import { useTRPC } from '@/trpc/react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 
 export function useUser() {
   const trpc = useTRPC()
@@ -9,39 +9,26 @@ export function useUser() {
 
 export function useLogout() {
   const trpc = useTRPC()
-  const queryClient = useQueryClient()
   const { mutateAsync, ...mutation } = useMutation(
     trpc.user.logout.mutationOptions({
-      onSettled: () => {
-        void queryClient.invalidateQueries(trpc.user.me.queryOptions())
-      },
+      onSettled: () => location.reload(),
     }),
   )
   return {
     ...mutation,
-    logout: async () => {
-      await mutateAsync()
-      await queryClient.invalidateQueries(trpc.user.me.queryOptions())
-      location.reload()
-    },
+    logout: () => mutateAsync(),
   }
 }
 
 export function useRemoveWcaAccount() {
   const trpc = useTRPC()
-  const queryClient = useQueryClient()
   const { mutateAsync, ...mutation } = useMutation(
     trpc.user.removeWcaAccount.mutationOptions({
-      onSettled: () => {
-        void queryClient.invalidateQueries(trpc.user.me.queryOptions())
-      },
+      onSettled: () => location.reload(),
     }),
   )
   return {
     ...mutation,
-    removeWcaAccount: async () => {
-      await mutateAsync()
-      await queryClient.invalidateQueries(trpc.user.me.queryOptions())
-    },
+    removeWcaAccount: () => mutateAsync(),
   }
 }

--- a/src/frontend/ui/popovers/popover.tsx
+++ b/src/frontend/ui/popovers/popover.tsx
@@ -8,6 +8,7 @@ import { UnderlineButton } from '../buttons'
 const Popover = PopoverPrimitive.Root
 const PopoverTrigger = PopoverPrimitive.Trigger
 const PopoverAnchor = PopoverPrimitive.Anchor
+const PopoverPortal = PopoverPrimitive.Portal
 
 function PopoverContent({
   className,
@@ -22,9 +23,9 @@ function PopoverContent({
   return (
     <PopoverPrimitive.Content
       onOpenAutoFocus={(event) => event.preventDefault()}
-      collisionPadding={20}
+      collisionPadding={12}
       className={cn(
-        'relative z-20 flex flex-col items-center gap-2 whitespace-normal rounded-xl bg-black-100 p-4 text-center animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        'relative z-20 flex max-w-[calc(100vw-12px*2)] flex-col items-center gap-2 whitespace-normal rounded-xl bg-black-100 p-4 text-center animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
         {
           'mb-2 after:absolute after:-bottom-3 after:h-3 after:w-full':
             !withArrow,
@@ -91,7 +92,7 @@ export function HoverPopover({
       >
         {trigger}
       </PopoverTrigger>
-      <PopoverPrimitive.PopoverPortal>
+      <PopoverPortal>
         <PopoverContent
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
@@ -99,7 +100,7 @@ export function HoverPopover({
         >
           {content}
         </PopoverContent>
-      </PopoverPrimitive.PopoverPortal>
+      </PopoverPortal>
     </Popover>
   )
 }
@@ -110,4 +111,5 @@ export {
   PopoverAnchor,
   PopoverCloseButton,
   PopoverContent,
+  PopoverPortal,
 }

--- a/src/frontend/ui/tooltip.tsx
+++ b/src/frontend/ui/tooltip.tsx
@@ -5,10 +5,9 @@ import * as TooltipPrimitive from '@radix-ui/react-tooltip'
 import { cn } from '../utils/cn'
 
 const TooltipProvider = TooltipPrimitive.Provider
-
 const Tooltip = TooltipPrimitive.Root
-
 const TooltipTrigger = TooltipPrimitive.Trigger
+const TooltipPortal = TooltipPrimitive.Portal
 
 function TooltipContent({
   className,
@@ -31,4 +30,10 @@ function TooltipContent({
   )
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+  TooltipPortal,
+}

--- a/src/globals.css
+++ b/src/globals.css
@@ -24,6 +24,10 @@
   svg {
     @apply text-[1rem];
   }
+
+  [data-radix-popper-content-wrapper] {
+    min-width: auto !important;
+  }
 }
 
 @layer components {


### PR DESCRIPTION
- **feat(ui): add `<SolveOngoingLink />` to `<OngoingContestBanner />` on tablet**
- **feat(ui): add "crazy finger tricks" splash text**
- **fix(frontend): just reload on logout or wca connection removal**
- **feat(ui): add hint about leaderboard updating after contest end**

Closes: #52
Closes #71