### PR TITLE
Feat: simulator in settings on mobile

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,7 @@ env:
 jobs:
   CD:
     environment: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-8vcpu-ubuntu-2204
     permissions:
       contents: read
       packages: write
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: useblacksmith/build-push-action@v1
         with:
           context: .
           push: true

--- a/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/simulator.lazy.tsx
+++ b/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/simulator.lazy.tsx
@@ -227,36 +227,6 @@ export default function Simulator({
         href='https://fonts.googleapis.com/css2?family=M+PLUS+1+Code&display=swap'
         rel='stylesheet'
       />
-      <style>
-        {`
-        body {
-          overscroll-behavior: none;
-        }
-        .touchcube {
-          position: absolute;
-          text-align: center;
-          user-select: none;
-        }
-        .touchcube tr td {
-          width: 33%;
-          height: 33%;
-        }
-        .touchcube.active {
-          background-color: #6666;
-          color: #fffa;
-        }
-        .touchcube.active td.touchto {
-          background-color: #0f0a;
-        }
-        .touchcube.active td.touchfrom {
-          background-color: #f00a;
-        }
-        .touchcube.board td {
-          border: 2px solid #6666;
-          border: 0.15rem solid #6666;
-        }
-        `}
-      </style>
       <div
         className='relative flex h-full items-center justify-center'
         onTouchStart={touchStartHandler}

--- a/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/use-simulator.ts
+++ b/src/app/(app)/contests/[contestSlug]/solve/_components/simulator/components/simulator/use-simulator.ts
@@ -19,6 +19,7 @@ export type SimulatorMoveListener = ({
   isSolved: boolean
 }) => void
 export function useTwistySimulator({
+  // TODO: use useControllableSimulator instead?
   containerRef,
   onMove,
   scramble,

--- a/src/app/(app)/settings/components/settings-preview-simulator.tsx
+++ b/src/app/(app)/settings/components/settings-preview-simulator.tsx
@@ -75,7 +75,7 @@ export function SettingsPreviewSimulator({
           Pro tip: press space to scramle/unscramble
         </span>
         <span className='hidden touch:block'>
-          Pro tip: double click to scramle/unscramble
+          Pro tip: double tap to scramle/unscramble
         </span>
       </p>
     </div>

--- a/src/app/(app)/settings/components/settings-preview-simulator.tsx
+++ b/src/app/(app)/settings/components/settings-preview-simulator.tsx
@@ -2,7 +2,7 @@
 
 import { useControllableSimulator } from '@/frontend/shared/simulator/use-controllable-simulator'
 import { cn } from '@/frontend/utils/cn'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, type RefObject } from 'react'
 import { useDebounceValue, useEventListener } from 'usehooks-ts'
 import { useSimulatorSettings } from '../hooks/queries'
 import { LoadingSpinner } from '@/frontend/ui'
@@ -28,20 +28,30 @@ export function SettingsPreviewSimulator({
   useEffect(() => setScramble(''), [settings?.colorscheme])
 
   const [isDirty, setIsDirty] = useState(false)
+
+  useEventListener(
+    'dblclick',
+    scrambleOnUnscramble,
+    simulatorRef as RefObject<HTMLDivElement>,
+  )
+
   useEventListener('keydown', (event) => {
     if (event.key === ' ') {
-      setIsDirty(!isDirty)
-      if (isDirty) {
-        setScramble(scramble === '' ? ' ' : '') // HACK: a little hack to trigger a scramble update (changing it form '' to '' wouldn't do anything)
-      } else {
-        setScramble(badRandomScramble())
-      }
-      return
+      scrambleOnUnscramble()
     }
 
     if (!isDirty && !isRotation(event)) setIsDirty(true)
     applyKeyboardMove(event)
   })
+
+  function scrambleOnUnscramble() {
+    if (isDirty) {
+      setScramble(scramble === '' ? ' ' : '') // HACK: a little hack to trigger a scramble update (changing it form '' to '' wouldn't do anything)
+    } else {
+      setScramble(badRandomScramble())
+    }
+    setIsDirty(!isDirty)
+  }
 
   if (!settings) {
     return (
@@ -56,12 +66,17 @@ export function SettingsPreviewSimulator({
       <div
         ref={simulatorRef}
         className={cn(
-          'pointer-events-none flex h-[300px] w-[300px] items-center justify-center rounded-2xl bg-black-80 touch:hidden [&>div]:flex [&>div]:justify-center',
+          'flex h-[300px] w-[300px] items-center justify-center rounded-2xl bg-black-80',
           className,
         )}
       />
       <p className='caption -mt-4 text-center text-grey-40'>
-        Pro tip: press space to scramle/unscramble
+        <span className='touch:hidden'>
+          Pro tip: press space to scramle/unscramble
+        </span>
+        <span className='hidden touch:block'>
+          Pro tip: double click to scramle/unscramble
+        </span>
       </p>
     </div>
   )

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -17,7 +17,7 @@ export default async function SettingsPage() {
         <div className='flex md:flex-col'>
           <SettingsList />
           <div className='md:mt-4 md:self-start'>
-            <SettingsPreviewSimulator className='pointer-events-none aspect-square w-[300px] touch:hidden' />
+            <SettingsPreviewSimulator />
           </div>
         </div>
       </div>

--- a/src/frontend/shared/simulator/use-controllable-simulator.tsx
+++ b/src/frontend/shared/simulator/use-controllable-simulator.tsx
@@ -1,3 +1,4 @@
+import { useIsTouchDevice } from '@/frontend/utils/use-media-query'
 import { useResizeObserver } from '@/frontend/utils/use-resize-observer'
 import type { Discipline, SimulatorSettings } from '@/types'
 import { useRef, useState, useEffect, useMemo } from 'react'
@@ -19,6 +20,7 @@ export function useControllableSimulator({
 
   const memoizedSettings = useMemo(() => JSON.stringify(settings), [settings])
 
+  const isTouchDevice = useIsTouchDevice()
   useEffect(() => {
     const parsedSettings = JSON.parse(
       // TODO: fix this differently, this is a dirty hack
@@ -32,7 +34,7 @@ export function useControllableSimulator({
       {
         puzzle: SIMULATOR_DISCIPLINES_MAP[discipline].puzzle,
         animationDuration: parsedSettings.animationDuration ?? 100,
-        allowDragging: false,
+        allowDragging: isTouchDevice ?? false,
         colorscheme: parsedSettings.colorscheme,
       },
       // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/vendor/cstimer/twisty/twisty.js
+++ b/vendor/cstimer/twisty/twisty.js
@@ -6,6 +6,36 @@ import $ from 'jquery'
 import THREE from '../threemin'
 import kernel from '../kernel'
 
+const touchGridStyles = `
+body {
+  overscroll-behavior: none;
+}
+.touchcube {
+  position: absolute;
+  inset: 0;
+  text-align: center;
+  user-select: none;
+}
+.touchcube tr td {
+  width: 33%;
+  height: 33%;
+}
+.touchcube.active {
+  background-color: #6666;
+  color: #fffa;
+}
+.touchcube.active td.touchto {
+  background-color: #0f0a;
+}
+.touchcube.active td.touchfrom {
+  background-color: #f00a;
+}
+.touchcube.board td {
+  border: 2px solid #6666;
+  border: 0.15rem solid #6666;
+}
+`
+
 /*
  * twisty.js
  *
@@ -135,6 +165,9 @@ const twistyjs = (function () {
       touchCube.append(trs)
 
       if (twistyType.allowDragging) {
+        const css = document.createElement('style')
+        css.innerHTML = touchGridStyles
+        twistyContainer.append(css)
         touchCube.appendTo(twistyContainer)
         touchCube.on('mousedown', onTouchDown)
         touchCube.on('mousemove', onTouchMove)


### PR DESCRIPTION
- **fix: move touchcube inline styles to cstimer/twisty**
- **fix(frontend): display the simulator (also with touchcube) in settings on mobile**
- **add back blacksmith to `cd.yaml`**
